### PR TITLE
Added namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ $prefix { }
 $(prefix)_button { }
 ```
 
+## Namespaces
+
+If you want to group related variables together you can use a namespace rule:
+
+```css
+%myNamespace {
+    red: #f33;
+    myWeight: bold
+}
+
+p {
+    color: $myNamespace.red;
+    font-weight: $myNamespace.red;
+}
+
+```
+
 ## Usage
 
 Without options:

--- a/test/test.js
+++ b/test/test.js
@@ -79,4 +79,12 @@ describe('postcss-simple-vars', function () {
         test('a{ zero: $zero }', 'a{ zero: 0 }', { variables: { zero: 0 } });
     });
 
+    it('Allows definition of namespaces', function () {
+        test('%namespace{ width: 10px } a{ width: $namespace.width }', 'a{ width: 10px }');
+    });
+
+    it('namespaces can accept multiple properties', function () {
+        test('%namespace{ width: 10px; potato: red } a{ width: $namespace.width; color: $namespace.potato }', 'a{ width: 10px; color: red }');
+    });
+
 });


### PR DESCRIPTION
#1 
## Namespaces

If you want to group related variables together you can use a namespace rule:

```css
%myNamespace {
    red: #f33;
    myWeight: bold
}

p {
    color: $myNamespace.red;
    font-weight: $myNamespace.red;
}

```

I kind of prefer
```css
$myNamespace {
    red: #f33;
    myWeight: bold
}
```
but that was conflicting with the selector use cases so I'm using another identifier. I don't like how it's asymmetrical with its usage, but maybe it's still the right way to go. I think this lends itself well to other extensions like a function to turn an object directly into properties. e.g. ```p{expand($myNamespace)}```

Thoughts?