### PR TITLE
add option to allow to warn on undefined variables without throwing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,15 @@ describe('postcss-simple-vars', function () {
         }).to.throw('<css input>:1:4: Undefined variable $size');
     });
 
+    it('warns on unknown variable', function () {
+        var result = postcss(vars({warn: true})).process('a{ width: -$size }');
+        expect(result.css).to.eql('a{ width: -$size }');
+        expect(result).to.have.property('messages')
+            .that.is.an('array');
+        expect(result.messages).to.have.length(1);
+        expect(result.messages[0].text).to.eql('Undefined variable $size');
+    });
+
     it('allows to silent errors', function () {
         test('a{ width: $size }', 'a{ width: $size }', { silent: true });
     });


### PR DESCRIPTION
This commit adds an option to warn when you hit an undefined variable.  This patch continues processing the css similarly to {silent: true} but also adds a warning message.  This is useful to provide feedback for linting purposes.

This patch is unnecessarily ugly because node.warn() doesn't seem to exist as per:

https://github.com/postcss/postcss/blob/master/docs/api.md#nodewarnresult-message

I didn't investigate the source cause of why the convenience method didn't exist on the node and instead changed the method signatures to pass around "result" to facilitate calling result.warn directly.

It'd probably be worth investigating why the node does not have the warn method instead of accepting this patch verbatim.  Maybe I just missed something.  

Let me know what you think about this functionality.