### PR TITLE
pass variable info to postcss.process(result.messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,16 @@ Left unknown variables in CSS and do not throw an error. Default is `false`.
 
 Set value only for variables from this object.
 Other variables will not be changed. It is useful for PostCSS plugin developers.
+
+## Messages
+
+postcss-simple-vars passes result.messages for each variable
+
+```
+{
+    plugin: 'postcss-simple-vars',
+    type: 'variable',
+    name: string, // variable name
+    value: string // variable value
+}
+```

--- a/index.js
+++ b/index.js
@@ -142,6 +142,15 @@ module.exports = postcss.plugin('postcss-simple-vars', function (opts) {
             }
         });
 
+        Object.keys(variables).forEach(function (key) {
+            result.messages.push({
+                plugin: 'postcss-simple-vars',
+                type: 'variable',
+                name: key,
+                value: variables[key]
+            });
+        });
+
         if ( opts.onVariables ) {
             opts.onVariables(variables);
         }

--- a/index.test.js
+++ b/index.test.js
@@ -7,6 +7,7 @@ function run(input, output, opts) {
         .then(result => {
             expect(result.css).toEqual(output);
             expect(result.warnings().length).toBe(0);
+            return result;
         });
 }
 
@@ -145,6 +146,26 @@ it('overrides unknown variable', () => {
 
 it('supports nested vairables', () => {
     run('$one: 1; $p: on; test: $($(p)e)', 'test: 1');
+});
+
+it('export variables to postcss result.messages', () => {
+    return run('$one: 1; $p: on; test: $one', 'test: 1')
+      .then(function (result) {
+          expect(result.messages).toEqual([
+              {
+                  plugin: 'postcss-simple-vars',
+                  type: 'variable',
+                  name: 'one',
+                  value: '1'
+              },
+              {
+                  plugin: 'postcss-simple-vars',
+                  type: 'variable',
+                  name: 'p',
+                  value: 'on'
+              }
+          ]);
+      });
 });
 
 it('overrides default variables', () => {


### PR DESCRIPTION
give other plugins access variable name/values.

as an example, for https://github.com/carlhopf/postcssify2 this enables the following usage

```vars.css```

```css
$color: green;
$width: 100px;
```

```index.js```

```javascript
const vars = require('./vars.css');

// 'green'
console.log(vars.color);
// '100px'
console.log(vars.width);
```