### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function variable(variables, node, str, name, opts, result) {
         }
 
         return str;
-    } 
+    }
 
     if ( typeof variables[name] !== 'undefined' ) {
         return variables[name];

--- a/index.js
+++ b/index.js
@@ -10,24 +10,28 @@ function variable(variables, node, str, name, opts, result) {
     if ( opts.only ) {
         if ( typeof opts.only[name] !== 'undefined' ) {
             return opts.only[name];
-        } else {
-            return str;
         }
 
-    } if ( typeof variables[name] !== 'undefined' ) {
+        return str;
+    } 
+
+    if ( typeof variables[name] !== 'undefined' ) {
         return variables[name];
 
-    } else if ( opts.silent ) {
+    }
+
+    if ( opts.silent ) {
         return str;
 
-    } else {
-        var fix = opts.unknown(node, name, result);
-        if ( fix ) {
-            return fix;
-        } else {
-            return str;
-        }
     }
+
+    var fix = opts.unknown(node, name, result);
+
+    if ( fix ) {
+        return fix;
+    }
+
+    return str;
 }
 
 function simpleSyntax(variables, node, str, opts, result) {


### PR DESCRIPTION
Using an else (or elseif) after a return is redundant.
Removing these makes the indentation less and more readable. Easier to see what is going on.