### PR TITLE
test: added failing test for postcss-hexrgba plugin

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -42,6 +42,14 @@ it('works with postcss-each', () => {
   )
 })
 
+it('works with postcss-hexrgba', () => {
+  runWithPlugins(
+    [plugin(), require('postcss-hexrgba')],
+    '$color-red: #FF0000; .a { color: rgba($color-red,0.10); }',
+    '.a { color: rgba(255,0,0,0.10); }'
+  )
+})
+
 it('replaces variables in values', () => {
   run(
     '$size: 10px;\na{ width: $size; height: $size }',

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "postcss": "^8.2.4",
     "postcss-each": "^1.0.0",
     "postcss-for": "^2.1.1",
+    "postcss-hexrgba": "^2.0.1",
     "postcss-mixins": "^7.0.3",
     "postcss-sharec-config": "^0.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,6 +4500,14 @@ postcss-for@^2.1.1:
     postcss "^5.0.0"
     postcss-simple-vars "^2.0.0"
 
+postcss-hexrgba@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-hexrgba/-/postcss-hexrgba-2.0.1.tgz#c0200574277994ad061cd7a5267796331bb9a449"
+  integrity sha512-u3R4THvbCk3hNkbDquwhvP68QfMxjolgi4BD/hybR9n4/vVFWme5+kdSn/dIpH+UfEqfsWmIBg7ZYBTsI3pk/Q==
+  dependencies:
+    postcss "^7.0.14"
+    postcss-value-parser "^4.1.0"
+
 postcss-js@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-3.0.3.tgz#2f0bd370a2e8599d45439f6970403b5873abda33"
@@ -4571,6 +4579,11 @@ postcss-simple-vars@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-6.0.3.tgz#e66516c7fe980da3498f4a8ad400b9c53861806c"
   integrity sha512-fkNn4Zio8vN4vIig9IFdb8lVlxWnYR769RgvxCM6YWlFKie/nQaOcaMMMFz/s4gsfHW4/5bJW+i57zD67mQU7g==
+
+postcss-value-parser@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
+  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss-values-parser@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Hey! I noticed for my project when postcss-simple-vars is updated from 6.0.2 to 6.0.3, the [postcss-hexrgba](https://github.com/madeleineostoja/postcss-hexrgba) plugin fails to convert hex color codes to the rgba values needed.

I wrote this failing test so we can see if it's something to do with this plugin, or something awry in hexrgba.

The changes between 6.0.2 and 6.0.3 didn't look that substantial so I am not sure what broke... :thinking: 

![Screenshot from 2021-05-05 17-36-25](https://user-images.githubusercontent.com/1049837/117109749-7b61bf00-adc8-11eb-9fba-ceecce49c7ab.png)
