### PR TITLE
117: Support backslash sequences and unicode transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ If you want to escape `$` in the `content` property, use Unicode escape syntax.
 }
 ```
 
+If you want to use e.g. `:` in a selector variable, use the corresponding unicode escape sequence:
+
+```css
+/* Given */
+$selector: .my-component[data-emoji="\U0001f389"]\u003Adisabled;
+
+$selector {
+  width: 1px;
+}
+
+/* Generates */
+.my-component[data-emoji="🎉"]:disabled {
+  width: 1px;
+}
+```
+
+Note: Use `\u` for 4-digit sequences and `\U` for 8-digit sequences.
 
 ## Usage
 

--- a/index.test.js
+++ b/index.test.js
@@ -77,6 +77,24 @@ it('allows to use in negative numbers', () => {
   run('a{ a: -$a }', 'a{ a: -1 }', { variables: { a: 1 } })
 })
 
+it('transforms unicode escapes', () => {
+  run(
+    String.raw`$selector: .my-component[data-emoji="\U0001F389"]\u003Adisabled\u003Ahover; $selector { width: 1px }`,
+    '.my-component[data-emoji="🎉"]:disabled:hover { width: 1px }'
+  )
+})
+
+it('does not transform escaped backslashes', () => {
+  run(
+    String.raw`$selector: .my-component[data-emoji="\\U0001F389"]\\u003Adisabled\\u003Ahover; $selector { width: 1px }`,
+    String.raw`.my-component[data-emoji="\U0001F389"]\u003Adisabled\u003Ahover { width: 1px }`
+  )
+  run(
+    String.raw`$selector: .my-component[data-emoji="\\\\U0001F389"]\\\\u003Adisabled\\\\u003Ahover; $selector { width: 1px }`,
+    String.raw`.my-component[data-emoji="\\U0001F389"]\\u003Adisabled\\u003Ahover { width: 1px }`
+  )
+})
+
 it('replaces multiple variables', () => {
   run('a{ a: $a $a }', 'a{ a: 1 1 }', { variables: { a: 1 } })
 })


### PR DESCRIPTION
As detailed in issue #117, it was not previously possible to create
variables containing certain characters, specifically `:` (\u003A) in
the case of #117.

This PR introduces support for "backslash sequences", i.e. sequences
immediately following a backslash (`\`). Specifically, the following
support is introduced:
* Escaped backslash sequences, i.e. `\\u003A` => `\u003A`
* 4 character unicode escapes, i.e. `\u003A` => `:`
* 8 character unicode escapes, i.e. `\U0001f389` => `🎉`